### PR TITLE
initialize model once

### DIFF
--- a/src/sagemaker_pytorch_container/serving.py
+++ b/src/sagemaker_pytorch_container/serving.py
@@ -11,10 +11,12 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
-import logging
-import torch
 
-from sagemaker_containers.beta.framework import (content_types, encoders, env, modules, transformer, worker)
+import logging
+
+import torch
+from sagemaker_containers.beta.framework import (content_types, encoders, env, modules, transformer,
+                                                 worker)
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +44,8 @@ def default_input_fn(input_data, content_type):
     """
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     np_array = encoders.decode(input_data, content_type)
-    tensor = torch.FloatTensor(np_array) if content_type in content_types.UTF8_TYPES else torch.from_numpy(np_array)
+    tensor = torch.FloatTensor(
+        np_array) if content_type in content_types.UTF8_TYPES else torch.from_numpy(np_array)
     return tensor.to(device)
 
 
@@ -90,14 +93,20 @@ def _user_module_transformer(user_module):
                                    output_fn=output_fn)
 
 
+app = None
+
+
 def main(environ, start_response):
-    serving_env = env.ServingEnv()
-    user_module = modules.import_module_from_s3(serving_env.module_dir, serving_env.module_name)
+    global app
+    if app is None:
+        serving_env = env.ServingEnv()
+        user_module = modules.import_module_from_s3(serving_env.module_dir, serving_env.module_name)
 
-    user_module_transformer = _user_module_transformer(user_module)
+        user_module_transformer = _user_module_transformer(user_module)
 
-    user_module_transformer.initialize()
+        user_module_transformer.initialize()
 
-    app = worker.Worker(transform_fn=user_module_transformer.transform,
-                        module_name=serving_env.module_name)
+        app = worker.Worker(transform_fn=user_module_transformer.transform,
+                            module_name=serving_env.module_name)
+
     return app(environ, start_response)

--- a/test/integration/__init__.py
+++ b/test/integration/__init__.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
+
 import os
 
 resources_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'resources'))
@@ -25,3 +26,4 @@ model_cpu_dir = os.path.join(mnist_path, 'model_cpu')
 model_cpu_1d_dir = os.path.join(model_cpu_dir, '1d')
 model_gpu_dir = os.path.join(mnist_path, 'model_gpu')
 model_gpu_1d_dir = os.path.join(model_gpu_dir, '1d')
+call_model_fn_once_script = os.path.join(resources_path, 'call_model_fn_once.py')

--- a/test/integration/local/test_serving.py
+++ b/test/integration/local/test_serving.py
@@ -11,34 +11,42 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
+
 import json
-from six import StringIO, BytesIO
+
+import numpy as np
 import pytest
 import requests
-from test.utils import local_mode
 import torch
 import torch.utils.data
 import torch.utils.data.distributed
-from torchvision import datasets, transforms
-import numpy as np
 from sagemaker_containers.beta.framework import content_types
-from test.integration import training_dir, mnist_script, mnist_1d_script, model_cpu_dir, model_gpu_dir, \
+from six import StringIO, BytesIO
+from torchvision import datasets, transforms
+
+from test.integration import training_dir, mnist_script, mnist_1d_script, model_cpu_dir, \
+    model_gpu_dir, \
     model_cpu_1d_dir, call_model_fn_once_script
+from test.utils import local_mode
 
 
 @pytest.fixture(name='serve_cpu')
 def fixture_serve_cpu(docker_image, opt_ml):
     def serve(model_dir=model_cpu_dir, script=mnist_script):
-        return local_mode.serve(customer_script=script, model_dir=model_dir, image_name=docker_image,
+        return local_mode.serve(customer_script=script, model_dir=model_dir,
+                                image_name=docker_image,
                                 opt_ml=opt_ml)
+
     return serve
 
 
 @pytest.fixture(name='serve_gpu')
 def fixture_serve_gpu(docker_image, opt_ml):
     def serve(model_dir=model_gpu_dir, script=mnist_script):
-        return local_mode.serve(customer_script=script, model_dir=model_dir, image_name=docker_image,
+        return local_mode.serve(customer_script=script, model_dir=model_dir,
+                                image_name=docker_image,
                                 use_gpu=True, opt_ml=opt_ml)
+
     return serve
 
 
@@ -92,12 +100,14 @@ def test_serve_cpu_model_on_gpu(serve_gpu, test_loader):
         _assert_prediction_npy_json(test_loader, content_types.NPY, content_types.JSON)
 
 
-def test_serving_calls_model_fn_once(serve_cpu, tmpdir):
-    with serve_cpu(model_dir=str(tmpdir), script=call_model_fn_once_script):
-        assert b'output' == requests.post(local_mode.REQUEST_URL, data=b'input').content
-
-        # each will return 500 error if model_fn called during request handling
-        assert b'output' == requests.post(local_mode.REQUEST_URL, data=b'input').content
+def test_serving_calls_model_fn_once(docker_image, opt_ml, tmpdir):
+    with local_mode.serve(customer_script=call_model_fn_once_script, model_dir=None,
+                          image_name=docker_image,
+                          opt_ml=opt_ml, additional_env_vars=['SAGEMAKER_MODEL_SERVER_WORKERS=2']):
+        # call enough times to ensure multiple requests to a worker
+        for i in range(3):
+            # will return 500 error if model_fn called during request handling
+            assert b'output' == requests.post(local_mode.REQUEST_URL, data=b'input').content
 
 
 def _assert_prediction_npy_json(test_loader, request_type, accept):
@@ -126,8 +136,10 @@ def _get_mnist_batch(test_loader):
 
 
 def _make_prediction(data, request_type, accept):
-    serialized_output = requests.post(local_mode.REQUEST_URL, data=_serialize_input(data, request_type),
-                                      headers={'Content-type': request_type, 'Accept': accept}).content
+    serialized_output = requests.post(local_mode.REQUEST_URL,
+                                      data=_serialize_input(data, request_type),
+                                      headers={'Content-type': request_type,
+                                               'Accept': accept}).content
     return _deserialize_output(serialized_output, accept)
 
 

--- a/test/resources/call_model_fn_once.py
+++ b/test/resources/call_model_fn_once.py
@@ -1,0 +1,36 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import os
+
+
+def model_fn(model_dir):
+    lock_file = os.path.join(model_dir, 'model_fn.lock.{}'.format(os.getpid()))
+    if os.path.exists(lock_file):
+        raise RuntimeError('model_fn called more than once (lock: {})'.format(lock_file))
+
+    open(lock_file, 'a').close()
+
+    return 'model'
+
+
+def input_fn(data, content_type):
+    return data
+
+
+def predict_fn(data, model):
+    return b'output'
+
+
+def output_fn(prediction, accept):
+    return prediction

--- a/test/unit/test_serving.py
+++ b/test/unit/test_serving.py
@@ -11,23 +11,22 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
-import pytest
-import json
+
 import csv
+import json
+
 import numpy as np
-from six import StringIO, BytesIO
+import pytest
 import torch
 import torch.nn as nn
-from torch.autograd import Variable
-
+from mock import MagicMock
+from mock import patch
 from sagemaker_containers.beta.framework import (content_types, encoders)
+from six import StringIO, BytesIO
+from torch.autograd import Variable
 
 from sagemaker_pytorch_container.serving import main, default_model_fn, default_input_fn
 from sagemaker_pytorch_container.serving import default_predict_fn, default_output_fn
-
-from mock import MagicMock
-from mock import Mock
-from mock import patch
 
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
@@ -191,13 +190,8 @@ def test_default_output_fn_gpu():
 @patch('sagemaker_containers.beta.framework.transformer.Transformer.initialize')
 @patch('sagemaker_containers.beta.framework.env.ServingEnv', MagicMock())
 def test_hosting_start(mock_import_module, mock_worker, mock_transformer_init):
-    user_module = MagicMock()
-    user_module.model_fn = Mock(return_value=DummyModel())
-    mock_import_module.return_value = user_module
-    app = MagicMock()
-    mock_worker.return_value = app
     environ = MagicMock()
     start_response = MagicMock()
     main(environ, start_response)
     mock_transformer_init.assert_called()
-    app.assert_called_with(environ, start_response)
+    mock_worker.return_value.assert_called_with(environ, start_response)


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/awslabs/amazon-sagemaker-examples/issues/341

*Description of changes:*

- change serving.py so user_module initialization only happens once, instead of on each request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
