### PR TITLE
Use instance_type instead of the tag

### DIFF
--- a/test/integration/sagemaker/conftest.py
+++ b/test/integration/sagemaker/conftest.py
@@ -15,6 +15,7 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def skip_by_device_type(request, tag):
-    if (request.node.get_marker('skip_gpu') and 'gpu' in tag) or (request.node.get_marker('skip_cpu') and 'cpu' in tag):
-        pytest.skip('Skipping because tag is: {}'.format(tag))
+def skip_by_device_type(request, processor):
+    if (request.node.get_marker('skip_gpu') and processor == 'gpu') or \
+            (request.node.get_marker('skip_cpu') and processor == 'cpu'):
+        pytest.skip('Skipping because running \'{}\' image'.format(processor))

--- a/test/integration/sagemaker/conftest.py
+++ b/test/integration/sagemaker/conftest.py
@@ -15,7 +15,8 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def skip_by_device_type(request, processor):
-    if (request.node.get_marker('skip_gpu') and processor == 'gpu') or \
-            (request.node.get_marker('skip_cpu') and processor == 'cpu'):
-        pytest.skip('Skipping because running \'{}\' image'.format(processor))
+def skip_by_device_type(request, instance_type):
+    is_gpu = instance_type[3] in ['g', 'p']
+    if (request.node.get_marker('skip_gpu') and is_gpu) or \
+            (request.node.get_marker('skip_cpu') and not is_gpu):
+        pytest.skip('Skipping because running on \'{}\' instance'.format(instance_type))


### PR DESCRIPTION
Use instance_type instead of the tag to determine whether the test needs to be skipped.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
