### PR TITLE
bump minimum sagemaker-containers version to 2.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         'Programming Language :: Python :: 3.5',
     ],
 
-    install_requires=['numpy', 'sagemaker-containers >= 2.1.0', 'torch==0.4.0', 'retrying', 'six'],
+    install_requires=['numpy', 'sagemaker-containers >= 2.2.0', 'torch==0.4.0', 'retrying', 'six'],
     extras_require={
         'test': ['tox', 'flake8', 'coverage', 'pytest', 'pytest-cov', 'pytest-xdist', 'mock', 'Flask', 'boto3>=1.4.8',
                  'docker-compose', 'sagemaker', 'PyYAML', 'torchvision']


### PR DESCRIPTION
There was a breaking change in [SageMaker Containers 2.2.0](https://github.com/aws/sagemaker-containers/blob/master/CHANGELOG.rst#220), which #57 took into account.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
