### PR TITLE
Remove version restrictions of sagemaker-containers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         'Programming Language :: Python :: 3.5',
     ],
 
-    install_requires=['numpy', 'sagemaker-containers==2.1.0', 'Pillow', 'retrying', 'six'],
+    install_requires=['numpy', 'sagemaker-containers', 'Pillow', 'retrying', 'six'],
     extras_require={
         'test': ['tox', 'flake8', 'coverage', 'pytest', 'pytest-cov', 'pytest-xdist', 'mock',
                  'Flask', 'boto3>=1.4.8', 'docker-compose', 'sagemaker', 'PyYAML']

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         'Programming Language :: Python :: 3.5',
     ],
 
-    install_requires=['numpy', 'sagemaker-containers', 'Pillow', 'retrying', 'six'],
+    install_requires=['numpy', 'sagemaker-containers>=2.1.0', 'Pillow', 'retrying', 'six'],
     extras_require={
         'test': ['tox', 'flake8', 'coverage', 'pytest', 'pytest-cov', 'pytest-xdist', 'mock',
                  'Flask', 'boto3>=1.4.8', 'docker-compose', 'sagemaker', 'PyYAML']

--- a/test/unit/test_serving.py
+++ b/test/unit/test_serving.py
@@ -21,7 +21,7 @@ import torch
 import torch.nn as nn
 from mock import MagicMock
 from mock import patch
-from sagemaker_containers.beta.framework import (content_types, encoders)
+from sagemaker_containers.beta.framework import (content_types, errors)
 from six import StringIO, BytesIO
 from torch.autograd import Variable
 
@@ -93,7 +93,7 @@ def test_default_input_fn_npy(tensor):
 
 
 def test_default_input_fn_bad_content_type():
-    with pytest.raises(encoders.UnsupportedFormatError):
+    with pytest.raises(errors.UnsupportedFormatError):
         default_input_fn('', 'application/not_supported')
 
 
@@ -171,7 +171,7 @@ def test_default_output_fn_csv_float():
 
 
 def test_default_output_fn_bad_accept():
-    with pytest.raises(encoders.UnsupportedFormatError):
+    with pytest.raises(errors.UnsupportedFormatError):
         default_output_fn('', 'application/not_supported')
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Remove the version restrictions of sagemaker-containers in setup.py

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
