### PR TITLE
Remove "requsests" from tests dependencies.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
                       'torch==1.0.0'],
     extras_require={
         'test': ['boto3>=1.4.8', 'coverage', 'docker-compose', 'flake8', 'Flask', 'mock',
-                 'pytest', 'pytest-cov', 'pytest-xdist', 'PyYAML', 'requests', 'sagemaker',
-                 'torchvision', 'tox']
+                 'pytest', 'pytest-cov', 'pytest-xdist', 'PyYAML', 'sagemaker', 'torchvision',
+                 'tox']
     },
 )


### PR DESCRIPTION
Remove "requsests" from tests dependencies to avoid regular conflicts with "requests" package from "sagemaker" dependencies.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
