### PR TITLE
freeze pip version to <=18.1

### DIFF
--- a/docker/1.0.0/base/Dockerfile.cpu
+++ b/docker/1.0.0/base/Dockerfile.cpu
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends software-proper
 # Install pip
 RUN cd /tmp && \
     curl -O https://bootstrap.pypa.io/get-pip.py && \
-    python get-pip.py && rm get-pip.py
+    python get-pip.py 'pip<=18.1' && rm get-pip.py
 
 # Python won’t try to write .pyc or .pyo files on the import of source modules
 # Force stdin, stdout and stderr to be totally unbuffered. Good for logging

--- a/docker/1.0.0/base/Dockerfile.gpu
+++ b/docker/1.0.0/base/Dockerfile.gpu
@@ -29,4 +29,4 @@ RUN cd /tmp && \
 ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1 LANG=C.UTF-8 LC_ALL=C.UTF-8
 
 RUN pip install --no-cache-dir Pillow retrying six torch torchvision && \
-    if [ $py_version -eq 3 ]; then pip install --no-cache-dir fastai; fi
+    if [ $py_version -eq 3 ]; then pip install --no-cache-dir fastai==1.0.40; fi

--- a/docker/1.0.0/base/Dockerfile.gpu
+++ b/docker/1.0.0/base/Dockerfile.gpu
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends software-proper
 # Install pip
 RUN cd /tmp && \
     curl -O https://bootstrap.pypa.io/get-pip.py && \
-    python get-pip.py && rm get-pip.py
+    python get-pip.py 'pip<=18.1' && rm get-pip.py
 
 # Python won’t try to write .pyc or .pyo files on the import of source modules
 # Force stdin, stdout and stderr to be totally unbuffered. Good for logging

--- a/docker/1.0.0/base/Dockerfile.gpu
+++ b/docker/1.0.0/base/Dockerfile.gpu
@@ -29,4 +29,4 @@ RUN cd /tmp && \
 ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1 LANG=C.UTF-8 LC_ALL=C.UTF-8
 
 RUN pip install --no-cache-dir Pillow retrying six torch torchvision && \
-    if [ $py_version -eq 3 ]; then pip install --no-cache-dir fastai==1.0.40; fi
+    if [ $py_version -eq 3 ]; then pip install --no-cache-dir fastai==1.0.39; fi

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,9 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.6',
     ],
-
-    install_requires=['numpy', 'Pillow', 'retrying', 'sagemaker-containers>=2.3.5', 'six',
+    # freeze numpy version because of the python2 bug
+    # in 16.0: https://github.com/numpy/numpy/pull/12754
+    install_requires=['numpy<=1.15.4', 'Pillow', 'retrying', 'sagemaker-containers>=2.3.5', 'six',
                       'torch==1.0.0'],
     extras_require={
         'test': ['boto3>=1.4.8', 'coverage', 'docker-compose', 'flake8', 'Flask', 'mock',


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
pip 19.0 gets released today and there's error during base image build using pip 19.0. The error is:

Traceback (most recent call last): 
File "/usr/local/lib/python2.7/dist-packages/pip/_internal/cli/base_command.py", line 176, in main 
status = self.run(options, args) 
File "/usr/local/lib/python2.7/dist-packages/pip/_internal/commands/install.py", line 346, in run 
session=session, autobuilding=True 
File "/usr/local/lib/python2.7/dist-packages/pip/_internal/wheel.py", line 848, in build 
assert building_is_possible 
AssertionError 

Although there seems workaround for this, it's hard to tell whether it's good or not since release notes are not available for pip 19.0 now. So the best way for now is to freeze pip to <=18.1.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
