### PR TITLE
Fix unicode display problem in py2 container

### DIFF
--- a/docker/1.0.0/base/Dockerfile.cpu
+++ b/docker/1.0.0/base/Dockerfile.cpu
@@ -26,7 +26,7 @@ RUN cd /tmp && \
 
 # Python won’t try to write .pyc or .pyo files on the import of source modules
 # Force stdin, stdout and stderr to be totally unbuffered. Good for logging
-ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1 LANG=C.UTF-8 LC_ALL=C.UTF-8
+ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1 PYTHONIOENCODING=UTF-8 LANG=C.UTF-8 LC_ALL=C.UTF-8
 
 # Install dependencies from pip
 RUN if [ $py_version -eq 3 ]; \

--- a/docker/1.0.0/base/Dockerfile.gpu
+++ b/docker/1.0.0/base/Dockerfile.gpu
@@ -26,7 +26,7 @@ RUN cd /tmp && \
 
 # Python won’t try to write .pyc or .pyo files on the import of source modules
 # Force stdin, stdout and stderr to be totally unbuffered. Good for logging
-ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1 LANG=C.UTF-8 LC_ALL=C.UTF-8
+ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1 PYTHONIOENCODING=UTF-8 LANG=C.UTF-8 LC_ALL=C.UTF-8
 
 RUN pip install --no-cache-dir Pillow retrying six torch torchvision && \
     if [ $py_version -eq 3 ]; then pip install --no-cache-dir fastai==1.0.39; fi


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/sagemaker-containers/issues/159

*Description of changes:*
Add PYTHONIOENCODING=UTF-8 for python 2 container to encode with utf-8 as default.

Reference:
https://docs.python.org/3/using/cmdline.html#envvar-PYTHONIOENCODING

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
