### PR TITLE
Add Download Flag to MNIST dataset test

### DIFF
--- a/test/integration/local/test_serving.py
+++ b/test/integration/local/test_serving.py
@@ -95,7 +95,7 @@ def _assert_prediction_csv(test_loader, accept):
 
 def _get_test_data_loader(batch_size):
     return torch.utils.data.DataLoader(
-        datasets.MNIST(training_dir, train=False, transform=transforms.Compose([
+        datasets.MNIST(training_dir, train=False, download=True, transform=transforms.Compose([
             transforms.ToTensor(),
             transforms.Normalize((0.1307,), (0.3081,))
         ])),

--- a/test/resources/mnist/mnist.py
+++ b/test/resources/mnist/mnist.py
@@ -54,7 +54,7 @@ class Net(nn.Module):
 
 def _get_train_data_loader(batch_size, training_dir, is_distributed, **kwargs):
     logger.info("Get train data loader")
-    dataset = datasets.MNIST(training_dir, train=True, transform=transforms.Compose([
+    dataset = datasets.MNIST(training_dir, train=True, download=True, transform=transforms.Compose([
         transforms.ToTensor(),
         transforms.Normalize((0.1307,), (0.3081,))
     ]))
@@ -66,7 +66,7 @@ def _get_train_data_loader(batch_size, training_dir, is_distributed, **kwargs):
 def _get_test_data_loader(test_batch_size, training_dir, **kwargs):
     logger.info("Get test data loader")
     return torch.utils.data.DataLoader(
-        datasets.MNIST(training_dir, train=False, transform=transforms.Compose([
+        datasets.MNIST(training_dir, train=False, download=True, transform=transforms.Compose([
             transforms.ToTensor(),
             transforms.Normalize((0.1307,), (0.3081,))
         ])),


### PR DESCRIPTION
recently the MNIST dataset is not available in the torchvision
install, adding download=True fixes the issue and avoids
the tests being broken.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
