### PR TITLE
Freeze TorchVision to 0.2.1

### DIFF
--- a/docker/1.0.0/base/Dockerfile.cpu
+++ b/docker/1.0.0/base/Dockerfile.cpu
@@ -32,4 +32,4 @@ ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1 PYTHONIOENCODING=UTF-8 LANG=C.U
 RUN if [ $py_version -eq 3 ]; \
         then pip install --no-cache-dir http://download.pytorch.org/whl/cpu/torch-1.0.0-cp36-cp36m-linux_x86_64.whl fastai; \
         else pip install --no-cache-dir http://download.pytorch.org/whl/cpu/torch-1.0.0-cp27-cp27mu-linux_x86_64.whl; fi && \
-    pip install --no-cache-dir Pillow retrying six torchvision
+    pip install --no-cache-dir Pillow retrying six torchvision==0.2.1

--- a/docker/1.0.0/base/Dockerfile.gpu
+++ b/docker/1.0.0/base/Dockerfile.gpu
@@ -28,5 +28,5 @@ RUN cd /tmp && \
 # Force stdin, stdout and stderr to be totally unbuffered. Good for logging
 ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1 PYTHONIOENCODING=UTF-8 LANG=C.UTF-8 LC_ALL=C.UTF-8
 
-RUN pip install --no-cache-dir Pillow retrying six torch torchvision && \
+RUN pip install --no-cache-dir Pillow retrying six torch torchvision==0.2.1 && \
     if [ $py_version -eq 3 ]; then pip install --no-cache-dir fastai==1.0.39; fi

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
                       'torch==1.0.0'],
     extras_require={
         'test': ['boto3>=1.4.8', 'coverage', 'docker-compose', 'flake8', 'Flask', 'mock',
-                 'pytest', 'pytest-cov', 'pytest-xdist', 'PyYAML', 'sagemaker', 'torchvision',
+                 'pytest', 'pytest-cov', 'pytest-xdist', 'PyYAML', 'sagemaker', 'torchvision==0.2.1',
                  'tox']
     },
 )


### PR DESCRIPTION
the current 1.0.0 container shipped with torchvision 0.2.1
there is a newever release 0.2.2 which is not fully backwards compatible
at least in the way the datasets are stored. This could impact
customers who suddenly receive a new version of a dependency w/o any
control over it.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
