### PR TITLE
Freeze PyYAML version to avoid conflict with Docker Compose

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
                       'torch==1.0.0'],
     extras_require={
         'test': ['boto3>=1.4.8', 'coverage', 'docker-compose', 'flake8', 'Flask', 'mock',
-                 'pytest', 'pytest-cov', 'pytest-xdist', 'PyYAML', 'sagemaker', 'torchvision==0.2.1',
+                 'pytest', 'pytest-cov', 'pytest-xdist', 'PyYAML==3.10', 'sagemaker', 'torchvision==0.2.1',
                  'tox']
     },
 )


### PR DESCRIPTION
*Description of changes:*
Fix for the following exception:

> ContextualVersionConflict: (PyYAML 5.1 (/usr/lib64/python2.7/dist-packages), Requirement.parse('PyYAML<4,>=3.10'), set(['docker-compose']))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
