### PR TITLE
Use the SageMaker Python SDK for local integ single-machine training tests

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -41,7 +41,7 @@ def pytest_addoption(parser):
     parser.addoption('--build-image', '-D', action='store_true')
     parser.addoption('--build-base-image', '-B', action='store_true')
     parser.addoption('--aws-id')
-    parser.addoption('--instance-type', default='local')
+    parser.addoption('--instance-type')
     parser.addoption('--install-container-support', '-C', action='store_true')
     parser.addoption('--docker-base-name', default='pytorch')
     parser.addoption('--region', default='us-west-2')
@@ -158,8 +158,10 @@ def fixture_aws_id(request):
 
 
 @pytest.fixture(name='instance_type', scope='session')
-def fixture_instance_type(request):
-    return request.config.getoption('--instance-type')
+def fixture_instance_type(request, processor):
+    provided_instance_type = request.config.getoption('--instance-type')
+    default_instance_type = 'local' if processor == 'cpu' else 'local_gpu'
+    return provided_instance_type or default_instance_type
 
 
 @pytest.fixture(name='docker_registry', scope='session')

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -20,7 +20,7 @@ import shutil
 import sys
 import tempfile
 
-from sagemaker import Session
+from sagemaker import LocalSession, Session
 from sagemaker.pytorch import PyTorch
 
 from test.utils import local_mode
@@ -145,6 +145,11 @@ def fixture_build_image(request, framework_version, py_version, processor, tag, 
 @pytest.fixture(scope='session', name='sagemaker_session')
 def fixture_sagemaker_session(region):
     return Session(boto_session=boto3.Session(region_name=region))
+
+
+@pytest.fixture(scope='session', name='sagemaker_local_session')
+def fixture_sagemaker_local_session(region):
+    return LocalSession(boto_session=boto3.Session(region_name=region))
 
 
 @pytest.fixture(name='aws_id', scope='session')

--- a/test/integration/local/test_single_machine_training.py
+++ b/test/integration/local/test_single_machine_training.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of

--- a/test/utils/local_mode_utils.py
+++ b/test/utils/local_mode_utils.py
@@ -1,0 +1,46 @@
+# Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+from contextlib import contextmanager
+import fcntl
+import os
+import tarfile
+import time
+
+from test.integration import resources_path
+
+LOCK_PATH = os.path.join(resources_path, 'local_mode_lock')
+
+
+@contextmanager
+def lock():
+    # Since Local Mode uses the same port for serving, we need a lock in order
+    # to allow concurrent test execution.
+    local_mode_lock_fd = open(LOCK_PATH, 'w')
+    local_mode_lock = local_mode_lock_fd.fileno()
+
+    fcntl.lockf(local_mode_lock, fcntl.LOCK_EX)
+
+    try:
+        yield
+    finally:
+        time.sleep(5)
+        fcntl.lockf(local_mode_lock, fcntl.LOCK_UN)
+
+
+def assert_files_exist(output_path, directory_file_map):
+    for directory, files in directory_file_map.items():
+        with tarfile.open(os.path.join(output_path, '{}.tar.gz'.format(directory))) as tar:
+            for f in files:
+                tar.getmember(f)

--- a/test/utils/local_mode_utils.py
+++ b/test/utils/local_mode_utils.py
@@ -12,31 +12,8 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
-from contextlib import contextmanager
-import fcntl
 import os
 import tarfile
-import time
-
-from test.integration import resources_path
-
-LOCK_PATH = os.path.join(resources_path, 'local_mode_lock')
-
-
-@contextmanager
-def lock():
-    # Since Local Mode uses the same port for serving, we need a lock in order
-    # to allow concurrent test execution.
-    local_mode_lock_fd = open(LOCK_PATH, 'w')
-    local_mode_lock = local_mode_lock_fd.fileno()
-
-    fcntl.lockf(local_mode_lock, fcntl.LOCK_EX)
-
-    try:
-        yield
-    finally:
-        time.sleep(5)
-        fcntl.lockf(local_mode_lock, fcntl.LOCK_UN)
 
 
 def assert_files_exist(output_path, directory_file_map):

--- a/test/utils/local_mode_utils.py
+++ b/test/utils/local_mode_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of


### PR DESCRIPTION
*Description of changes:*
Part 2 of some number for using the Python SDK in our integ tests (see #86).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
