### PR TITLE
Use dummy role in tests and update local failure integ test

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
                       'torch==1.0.0'],
     extras_require={
         'test': ['boto3>=1.4.8', 'coverage', 'docker-compose', 'flake8', 'Flask', 'mock',
-                 'pytest', 'pytest-cov', 'pytest-xdist', 'PyYAML==3.10', 'sagemaker', 'torchvision==0.2.1',
-                 'tox']
+                 'pytest', 'pytest-cov', 'pytest-xdist', 'PyYAML==3.10', 'sagemaker>=1.18.14',
+                 'torchvision==0.2.1', 'tox']
     },
 )

--- a/test/integration/local/test_single_machine_training.py
+++ b/test/integration/local/test_single_machine_training.py
@@ -18,12 +18,12 @@ import pytest
 from sagemaker.pytorch import PyTorch
 
 from test.utils.local_mode_utils import assert_files_exist
-from test.integration import data_dir, fastai_path, fastai_mnist_script, mnist_script, PYTHON3
+from test.integration import data_dir, fastai_path, fastai_mnist_script, mnist_script, PYTHON3, ROLE
 
 
 def test_mnist(docker_image, processor, instance_type, sagemaker_local_session, tmpdir):
     estimator = PyTorch(entry_point=mnist_script,
-                        role='SageMakerRole',
+                        role=ROLE,
                         image_name=docker_image,
                         train_instance_count=1,
                         train_instance_type=instance_type,
@@ -39,7 +39,7 @@ def test_fastai_mnist(docker_image, py_version, instance_type, sagemaker_local_s
         pytest.skip('Skipping the test because fastai supports >= Python 3.6.')
 
     estimator = PyTorch(entry_point=fastai_mnist_script,
-                        role='SageMakerRole',
+                        role=ROLE,
                         image_name=docker_image,
                         train_instance_count=1,
                         train_instance_type=instance_type,


### PR DESCRIPTION
With https://github.com/aws/sagemaker-python-sdk/pull/746, Local Mode exports training artifacts even after job failure, so we can now test for the existence of a failure file.

Also updated the role following #91 and https://github.com/aws/sagemaker-chainer-container/pull/77

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
