### PR TITLE
Bump minimum SageMaker Containers version to 2.4.6 and pin SageMaker Python SDK to 1.18.16

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.6',
     ],
-    install_requires=['numpy', 'Pillow', 'retrying', 'sagemaker-containers>=2.4.4', 'six',
+    install_requires=['numpy', 'Pillow', 'retrying', 'sagemaker-containers>=2.4.6', 'six',
                       'torch==1.0.0'],
     extras_require={
         'test': ['boto3>=1.4.8', 'coverage', 'docker-compose', 'flake8', 'Flask', 'mock',

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
                       'torch==1.0.0'],
     extras_require={
         'test': ['boto3>=1.4.8', 'coverage', 'docker-compose', 'flake8', 'Flask', 'mock',
-                 'pytest', 'pytest-cov', 'pytest-xdist', 'PyYAML==3.10', 'sagemaker>=1.18.14',
+                 'pytest', 'pytest-cov', 'pytest-xdist', 'PyYAML==3.10', 'sagemaker==1.18.16',
                  'torchvision==0.2.1', 'tox']
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.6',
     ],
-    install_requires=['numpy', 'Pillow', 'retrying', 'sagemaker-containers>=2.3.5', 'six',
+    install_requires=['numpy', 'Pillow', 'retrying', 'sagemaker-containers>=2.4.4', 'six',
                       'torch==1.0.0'],
     extras_require={
         'test': ['boto3>=1.4.8', 'coverage', 'docker-compose', 'flake8', 'Flask', 'mock',


### PR DESCRIPTION
That version of SageMaker Containers had a fix to honor the `SAGEMAKER_MODEL_SERVER_TIMEOUT` setting.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
