### PR TITLE
fix: disable test_mnist_gpu for py2 for now

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -183,3 +183,9 @@ def skip_by_device_type(request, use_gpu, instance_type):
     if (request.node.get_closest_marker('skip_gpu') and is_gpu) or \
             (request.node.get_closest_marker('skip_cpu') and not is_gpu):
         pytest.skip('Skipping because running on \'{}\' instance'.format(instance_type))
+
+
+@pytest.fixture(autouse=True)
+def skip_by_py_version(request, py_version):
+    if request.node.get_closest_marker('skip_py2') and py_version != 'py3':
+        pytest.skip('Skipping the mnist distributed training test if py_version is py2 for now')

--- a/test/integration/sagemaker/test_distributed_operations.py
+++ b/test/integration/sagemaker/test_distributed_operations.py
@@ -68,13 +68,9 @@ def test_dist_operations_fastai_gpu(sagemaker_session, ecr_image, py_version):
     _assert_s3_file_exists(sagemaker_session.boto_region_name, model_s3_url)
 
 
-# TODO: Fix this test after PyTorch 1.1 upgrade
 @pytest.mark.skip_cpu
+@pytest.mark.skip_py2
 def test_mnist_gpu(sagemaker_session, ecr_image, py_version, dist_gpu_backend):
-    if py_version != PYTHON3:
-        print('Skipping the test for now if py_version is py2')
-        return
-
     with timeout(minutes=DEFAULT_TIMEOUT):
         pytorch = PyTorch(entry_point=mnist_script,
                           role='SageMakerRole',

--- a/test/integration/sagemaker/test_distributed_operations.py
+++ b/test/integration/sagemaker/test_distributed_operations.py
@@ -68,8 +68,13 @@ def test_dist_operations_fastai_gpu(sagemaker_session, ecr_image, py_version):
     _assert_s3_file_exists(sagemaker_session.boto_region_name, model_s3_url)
 
 
+# TODO: Fix this test after PyTorch 1.1 upgrade
 @pytest.mark.skip_cpu
 def test_mnist_gpu(sagemaker_session, ecr_image, py_version, dist_gpu_backend):
+    if py_version != PYTHON3:
+        print('Skipping the test for now if py_version is py2')
+        return
+
     with timeout(minutes=DEFAULT_TIMEOUT):
         pytorch = PyTorch(entry_point=mnist_script,
                           role='SageMakerRole',

--- a/test/integration/sagemaker/test_mnist.py
+++ b/test/integration/sagemaker/test_mnist.py
@@ -20,24 +20,16 @@ from test.integration import training_dir, mnist_script, DEFAULT_TIMEOUT, PYTHON
 from test.integration.sagemaker.timeout import timeout, timeout_and_delete_endpoint
 
 
-# TODO: Fix this test after PyTorch 1.1 upgrade
 @pytest.mark.skip_gpu
+@pytest.mark.skip_py2
 def test_mnist_distributed_cpu(sagemaker_session, ecr_image, instance_type, dist_cpu_backend, py_version):
-    if py_version != PYTHON3:
-        print('Skipping the test for now if py_version is py2')
-        return
-
     instance_type = instance_type or 'ml.c4.xlarge'
     _test_mnist_distributed(sagemaker_session, ecr_image, instance_type, dist_cpu_backend)
 
 
-# TODO: Fix this test after PyTorch 1.1 upgrade
 @pytest.mark.skip_cpu
+@pytest.mark.skip_py2
 def test_mnist_distributed_gpu(sagemaker_session, ecr_image, instance_type, dist_gpu_backend, py_version):
-    if py_version != PYTHON3:
-        print('Skipping the test for now if py_version is py2')
-        return
-    
     instance_type = instance_type or 'ml.p2.xlarge'
     _test_mnist_distributed(sagemaker_session, ecr_image, instance_type, dist_gpu_backend)
 

--- a/test/integration/sagemaker/test_mnist.py
+++ b/test/integration/sagemaker/test_mnist.py
@@ -16,18 +16,28 @@ import numpy as np
 import pytest
 from sagemaker.pytorch import PyTorch
 
-from test.integration import training_dir, mnist_script, DEFAULT_TIMEOUT
+from test.integration import training_dir, mnist_script, DEFAULT_TIMEOUT, PYTHON3
 from test.integration.sagemaker.timeout import timeout, timeout_and_delete_endpoint
 
 
+# TODO: Fix this test after PyTorch 1.1 upgrade
 @pytest.mark.skip_gpu
-def test_mnist_distributed_cpu(sagemaker_session, ecr_image, instance_type, dist_cpu_backend):
+def test_mnist_distributed_cpu(sagemaker_session, ecr_image, instance_type, dist_cpu_backend, py_version):
+    if py_version != PYTHON3:
+        print('Skipping the test for now if py_version is py2')
+        return
+
     instance_type = instance_type or 'ml.c4.xlarge'
     _test_mnist_distributed(sagemaker_session, ecr_image, instance_type, dist_cpu_backend)
 
 
+# TODO: Fix this test after PyTorch 1.1 upgrade
 @pytest.mark.skip_cpu
-def test_mnist_distributed_gpu(sagemaker_session, ecr_image, instance_type, dist_gpu_backend):
+def test_mnist_distributed_gpu(sagemaker_session, ecr_image, instance_type, dist_gpu_backend, py_version):
+    if py_version != PYTHON3:
+        print('Skipping the test for now if py_version is py2')
+        return
+    
     instance_type = instance_type or 'ml.p2.xlarge'
     _test_mnist_distributed(sagemaker_session, ecr_image, instance_type, dist_gpu_backend)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Disable the test_mnist_gpu py2 test for now because it never passed. We will have a separate task to have it fixed after PyTorch 1.1 upgrade.

Also I didn't write a conftest function but followed the convention that other test in this file that skips because of python version. And we will remove the skip condition after we fix the issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
