### PR TITLE
Add /bin/bash as default CMD

### DIFF
--- a/docker/1.2.0/py2/Dockerfile.cpu
+++ b/docker/1.2.0/py2/Dockerfile.cpu
@@ -95,3 +95,4 @@ ENV SAGEMAKER_TRAINING_MODULE sagemaker_pytorch_container.training:main
 
 # Starts framework
 ENTRYPOINT ["bash", "-m", "start_with_right_hostname.sh"]
+CMD ["/bin/bash"]

--- a/docker/1.2.0/py2/Dockerfile.gpu
+++ b/docker/1.2.0/py2/Dockerfile.gpu
@@ -141,3 +141,4 @@ ENV SAGEMAKER_TRAINING_MODULE sagemaker_pytorch_container.training:main
 
 # Starts framework
 ENTRYPOINT ["bash", "-m", "start_with_right_hostname.sh"]
+CMD ["/bin/bash"]

--- a/docker/1.2.0/py3/Dockerfile.cpu
+++ b/docker/1.2.0/py3/Dockerfile.cpu
@@ -98,3 +98,4 @@ ENV SAGEMAKER_TRAINING_MODULE sagemaker_pytorch_container.training:main
 
 # Starts framework
 ENTRYPOINT ["bash", "-m", "start_with_right_hostname.sh"]
+CMD ["/bin/bash"]

--- a/docker/1.2.0/py3/Dockerfile.gpu
+++ b/docker/1.2.0/py3/Dockerfile.gpu
@@ -145,3 +145,4 @@ ENV SAGEMAKER_TRAINING_MODULE sagemaker_pytorch_container.training:main
 
 # Starts framework
 ENTRYPOINT ["bash", "-m", "start_with_right_hostname.sh"]
+CMD ["/bin/bash"]


### PR DESCRIPTION
Running the container like:
```
docker run -it <image_id> 
```
causes immediate exit unless supplied with a command such as /bin/bash as an argument. If provided as an argument, the bash script start_with_right_hostname.sh correctly evals it. 

*Description of changes:*
Adding /bin/bash as default CMD to start when container is started in interactive/daemon mode.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
