### PR TITLE
change: use regional endpoint for STS in builds

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -20,7 +20,7 @@ phases:
   pre_build:
     commands:
       - start-dockerd
-      - ACCOUNT=$(aws sts get-caller-identity --query 'Account' --output text)
+      - ACCOUNT=$(aws --region $AWS_DEFAULT_REGION sts --endpoint-url https://sts.$AWS_DEFAULT_REGION.amazonaws.com get-caller-identity --query 'Account' --output text)
       - PREPROD_IMAGE="$ACCOUNT.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$ECR_REPO"
       - PR_NUM=$(echo $CODEBUILD_SOURCE_VERSION | grep -o '[0-9]\+')
       - BUILD_ID="$(echo $CODEBUILD_BUILD_ID | sed -e 's/:/-/g')"


### PR DESCRIPTION
related:
* https://github.com/aws/sagemaker-mxnet-serving-container/pull/76
* https://github.com/aws/sagemaker-mxnet-container/pull/113
* https://github.com/aws/sagemaker-chainer-container/pull/107

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
