### PR TITLE
fix: remove call to deprecated function download_and_install

### DIFF
--- a/src/sagemaker_pytorch_container/training.py
+++ b/src/sagemaker_pytorch_container/training.py
@@ -47,6 +47,7 @@ def train(training_environment):
 
     logger.info('Invoking user training script.')
     try:
+        framework.modules.download_and_install(training_environment.module_dir)
         framework.entry_point.run(training_environment.module_dir, training_environment.user_entry_point,
                                   training_environment.to_cmd_args(), training_environment.to_env_vars(),
                                   capture_error=True, runner=framework.runner.ProcessRunnerType)

--- a/src/sagemaker_pytorch_container/training.py
+++ b/src/sagemaker_pytorch_container/training.py
@@ -47,7 +47,6 @@ def train(training_environment):
 
     logger.info('Invoking user training script.')
     try:
-        framework.modules.download_and_install(training_environment.module_dir)
         framework.entry_point.run(training_environment.module_dir, training_environment.user_entry_point,
                                   training_environment.to_cmd_args(), training_environment.to_env_vars(),
                                   capture_error=True, runner=framework.runner.ProcessRunnerType)

--- a/src/sagemaker_pytorch_container/training.py
+++ b/src/sagemaker_pytorch_container/training.py
@@ -47,7 +47,7 @@ def train(training_environment):
 
     logger.info('Invoking user training script.')
     try:
-        framework.modules.download_and_install(training_environment.module_dir)
+        framework.modules.import_module(training_environment.module_dir)
         framework.entry_point.run(training_environment.module_dir, training_environment.user_entry_point,
                                   training_environment.to_cmd_args(), training_environment.to_env_vars(),
                                   capture_error=True, runner=framework.runner.ProcessRunnerType)

--- a/test/unit/test_train.py
+++ b/test/unit/test_train.py
@@ -57,19 +57,16 @@ def fixture_user_module_with_save():
     return MagicMock(spec=['train', 'save'])
 
 
-@patch('sagemaker_containers.beta.framework.modules.download_and_install')
 @patch('sagemaker_containers.beta.framework.entry_point.run')
 @patch('socket.gethostbyname', MagicMock())
-def test_train(run_entry_point, download_and_install, training_env):
+def test_train(run_entry_point, training_env):
     train(training_env)
 
-    download_and_install.assert_called_with(training_env.module_dir)
     run_entry_point.assert_called_with(training_env.module_dir, training_env.user_entry_point,
                                        training_env.to_cmd_args(), training_env.to_env_vars(),
                                        capture_error=True, runner=framework.runner.ProcessRunnerType)
 
 
-@patch('sagemaker_containers.beta.framework.modules.download_and_install', MagicMock())
 @patch('sagemaker_containers.beta.framework.entry_point.run', MagicMock())
 @patch('socket.gethostbyname', MagicMock())
 def test_environment(training_env):
@@ -114,7 +111,6 @@ def test_dns_lookup_fail():
     assert not _dns_lookup('algo-1')
 
 
-@patch('sagemaker_containers.beta.framework.modules.download_and_install', MagicMock())
 @patch('sagemaker_containers.beta.framework.entry_point.run')
 @patch('socket.gethostbyname', MagicMock())
 def test_gloo_exception_intercepted(run_entry_point, training_env):
@@ -127,7 +123,6 @@ def test_gloo_exception_intercepted(run_entry_point, training_env):
     run_entry_point.assert_called()
 
 
-@patch('sagemaker_containers.beta.framework.modules.download_and_install', MagicMock())
 @patch('sagemaker_containers.beta.framework.entry_point.run')
 @patch('socket.gethostbyname', MagicMock())
 def test_user_script_error_raised(run_entry_point, training_env):

--- a/test/unit/test_train.py
+++ b/test/unit/test_train.py
@@ -57,19 +57,19 @@ def fixture_user_module_with_save():
     return MagicMock(spec=['train', 'save'])
 
 
-@patch('sagemaker_containers.beta.framework.modules.download_and_install')
+@patch('sagemaker_containers.beta.framework.modules.import_module')
 @patch('sagemaker_containers.beta.framework.entry_point.run')
 @patch('socket.gethostbyname', MagicMock())
-def test_train(run_entry_point, download_and_install, training_env):
+def test_train(run_entry_point, import_module, training_env):
     train(training_env)
 
-    download_and_install.assert_called_with(training_env.module_dir)
+    import_module.assert_called_with(training_env.module_dir)
     run_entry_point.assert_called_with(training_env.module_dir, training_env.user_entry_point,
                                        training_env.to_cmd_args(), training_env.to_env_vars(),
                                        capture_error=True, runner=framework.runner.ProcessRunnerType)
 
 
-@patch('sagemaker_containers.beta.framework.modules.download_and_install', MagicMock())
+@patch('sagemaker_containers.beta.framework.modules.import_module', MagicMock())
 @patch('sagemaker_containers.beta.framework.entry_point.run', MagicMock())
 @patch('socket.gethostbyname', MagicMock())
 def test_environment(training_env):
@@ -114,7 +114,7 @@ def test_dns_lookup_fail():
     assert not _dns_lookup('algo-1')
 
 
-@patch('sagemaker_containers.beta.framework.modules.download_and_install', MagicMock())
+@patch('sagemaker_containers.beta.framework.modules.import_module', MagicMock())
 @patch('sagemaker_containers.beta.framework.entry_point.run')
 @patch('socket.gethostbyname', MagicMock())
 def test_gloo_exception_intercepted(run_entry_point, training_env):
@@ -127,7 +127,7 @@ def test_gloo_exception_intercepted(run_entry_point, training_env):
     run_entry_point.assert_called()
 
 
-@patch('sagemaker_containers.beta.framework.modules.download_and_install', MagicMock())
+@patch('sagemaker_containers.beta.framework.modules.import_module', MagicMock())
 @patch('sagemaker_containers.beta.framework.entry_point.run')
 @patch('socket.gethostbyname', MagicMock())
 def test_user_script_error_raised(run_entry_point, training_env):

--- a/test/unit/test_train.py
+++ b/test/unit/test_train.py
@@ -57,16 +57,19 @@ def fixture_user_module_with_save():
     return MagicMock(spec=['train', 'save'])
 
 
+@patch('sagemaker_containers.beta.framework.modules.download_and_install')
 @patch('sagemaker_containers.beta.framework.entry_point.run')
 @patch('socket.gethostbyname', MagicMock())
-def test_train(run_entry_point, training_env):
+def test_train(run_entry_point, download_and_install, training_env):
     train(training_env)
 
+    download_and_install.assert_called_with(training_env.module_dir)
     run_entry_point.assert_called_with(training_env.module_dir, training_env.user_entry_point,
                                        training_env.to_cmd_args(), training_env.to_env_vars(),
                                        capture_error=True, runner=framework.runner.ProcessRunnerType)
 
 
+@patch('sagemaker_containers.beta.framework.modules.download_and_install', MagicMock())
 @patch('sagemaker_containers.beta.framework.entry_point.run', MagicMock())
 @patch('socket.gethostbyname', MagicMock())
 def test_environment(training_env):
@@ -111,6 +114,7 @@ def test_dns_lookup_fail():
     assert not _dns_lookup('algo-1')
 
 
+@patch('sagemaker_containers.beta.framework.modules.download_and_install', MagicMock())
 @patch('sagemaker_containers.beta.framework.entry_point.run')
 @patch('socket.gethostbyname', MagicMock())
 def test_gloo_exception_intercepted(run_entry_point, training_env):
@@ -123,6 +127,7 @@ def test_gloo_exception_intercepted(run_entry_point, training_env):
     run_entry_point.assert_called()
 
 
+@patch('sagemaker_containers.beta.framework.modules.download_and_install', MagicMock())
 @patch('sagemaker_containers.beta.framework.entry_point.run')
 @patch('socket.gethostbyname', MagicMock())
 def test_user_script_error_raised(run_entry_point, training_env):


### PR DESCRIPTION
*Description of changes:*
- The `sagemaker-containers` function `modules.download_and_install()` is deprecated and breaks network isolation.
- The function `modules.import_module()` contains the necessary functionality to download, extract, and import the module without breaking network isolation. It also supports `requirements.txt`. `modules.download_and_install()` has been replaced with `modules.import_module()` accordingly.
- The function `entry_point.run()` (which is called on the following line) contains some overlapping functionality with `modules.import_module()`, but it also runs the entry point. Upcoming work to refactor [sagemaker-containers](https://github.com/aws/sagemaker-containers/) will remove redundant functionality and deprecated code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
