### PR TITLE
skip on smexperiments import error

### DIFF
--- a/test/integration/sagemaker/test_experiments.py
+++ b/test/integration/sagemaker/test_experiments.py
@@ -22,11 +22,19 @@ from test.integration.sagemaker.timeout import timeout
 
 
 @pytest.mark.skip_py2_containers
-def test_training(sagemaker_session, ecr_image, instance_type):
+def test_training(sagemaker_session, ecr_image, instance_type, py_version):
 
-    from smexperiments.experiment import Experiment
-    from smexperiments.trial import Trial
-    from smexperiments.trial_component import TrialComponent
+    if py_version is None or '2' in py_version:
+        pytest.skip('Skipping python2 {}'.format(py_version))
+        return
+
+    try:
+        from smexperiments.experiment import Experiment
+        from smexperiments.trial import Trial
+        from smexperiments.trial_component import TrialComponent
+    except ImportError:
+        pytest.skip('smexperiments module not found')
+        return
 
     sm_client = sagemaker_session.sagemaker_client
 


### PR DESCRIPTION
skip on smexperiments import error

```
Starting
Process Process-48:
Running 'gloo' backend on 3 nodes and 72 processes. World size is 216.
Traceback (most recent call last):
Init process rank 72 on host 'algo-2'
  File "/opt/conda/lib/python3.6/multiprocessing/process.py", line 258, in _bootstrap
Init process rank 73 on host 'algo-2'
    self.run()
Init process rank 74 on host 'algo-2'
  File "/opt/conda/lib/python3.6/multiprocessing/process.py", line 93, in run
Init process rank 75 on host 'algo-2'
    self._target(*self._args, **self._kwargs)
Init process rank 76 on host 'algo-2'
  File "distributed_operations.py", line 234, in init_processes
Init process rank 77 on host 'algo-2'
    dist.init_process_group(backend=backend, rank=rank, world_size=world_size)
Init process rank 78 on host 'algo-2'
  File "/opt/conda/lib/python3.6/site-packages/torch/distributed/distributed_c10d.py", line 407, in init_process_group
Init process rank 79 on host 'algo-2'
    timeout=timeout)
Init process rank 80 on host 'algo-2'
  File "/opt/conda/lib/python3.6/site-packages/torch/distributed/distributed_c10d.py", line 475, in _new_process_group_helper
Init process rank 81 on host 'algo-2'
    timeout=timeout)
Init process rank 82 on host 'algo-2'
RuntimeError: [enforce fail at /AWS-PyTorch/third_party/gloo/gloo/transport/tcp/pair.cc:867] false. Invalid state: 1
Init process rank 83 on host 'algo-2'

2020-03-12 01:26:09 Training - Training image download completed. Training in progress.
------------------------------ Captured log call -------------------------------
estimator.py                74 WARNING  No framework_version specified, defaulting to version 0.4.
[1m[31m________________________________ test_training _________________________________[0m

sagemaker_session = <sagemaker.session.Session object at 0x7f938a6b26d0>
ecr_image = '841569659894.dkr.ecr.us-east-1.amazonaws.com/beta-pytorch-training:1.4.0-py3-cpu-build'
instance_type = 'ml.c5.18xlarge'

[1m    @pytest.mark.skip_py2_containers[0m
[1m    def test_training(sagemaker_session, ecr_image, instance_type):[0m
[1m    [0m
[1m>       from smexperiments.experiment import Experiment[0m
[1m[31mE       ImportError: No module named smexperiments.experiment[0m

[1m[31mtest/integration/sagemaker/test_experiments.py[0m:27: ImportError
[1m[31m============== 2 failed, 3 passed, 10 skipped in 2233.76 seconds ===============[0m


```