### PR TITLE
Install jupyter_client 5.3.4 in advance for py2 gpu image

### DIFF
--- a/docker/1.4.0/py2/Dockerfile.gpu
+++ b/docker/1.4.0/py2/Dockerfile.gpu
@@ -86,6 +86,7 @@ RUN ompi_info --parsable --all | grep mpi_built_with_cuda_support:value \
  && rm ~/miniconda.sh \
  && /opt/conda/bin/conda install -y anaconda \
     python=$PYTHON_VERSION \
+    jupyter_client==5.3.4 \
     numpy==1.16.4 \
     ipython==5.8.0 \
     mkl==2019.4 \


### PR DESCRIPTION
*Issue #, if available:*

Jupiter_client version 6.0.0 does not support python2.
https://tod.amazon.com/test_runs/53ba792d-6fb2-4192-9cab-f7eb5be8c880

*Description of changes:*
Install jupyter_client 5.3.4 in advance for py2 gpu image

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
