### PR TITLE
fix: upgrade sagemaker-containers to 2.8.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
 
     install_requires=[
         'retrying',
-        'sagemaker-containers>=2.6.2',
+        'sagemaker-containers>=2.8.2',
         'six>=1.12.0',
         'sagemaker-experiments==0.1.7;python_version>="3.6"'],
     extras_require={


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
sagemaker-containers==2.8.2 contains aws/sagemaker-containers#261, which has a fix for requirements.txt support.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
