### PR TITLE
upgrade Pillow and use pip to install

### DIFF
--- a/docker/1.4.0/py2/Dockerfile.cpu
+++ b/docker/1.4.0/py2/Dockerfile.cpu
@@ -73,7 +73,6 @@ RUN conda install -c conda-forge \
  && conda install -y \
     scikit-learn==0.20.3 \
     pandas==0.24.2 \
-    Pillow==6.2.0 \
     h5py==2.9.0 \
     requests==2.22.0 \
  && conda clean -ya \
@@ -88,6 +87,7 @@ COPY start_with_right_hostname.sh /usr/local/bin/start_with_right_hostname.sh
 RUN pip install --no-cache-dir \
     awscli \
     scipy==1.2.2 \
+    Pillow==6.2.2 \
     sphinxcontrib-websupport==1.1.2 \
     future \
     "sagemaker-pytorch-training<2" \

--- a/docker/1.4.0/py2/Dockerfile.gpu
+++ b/docker/1.4.0/py2/Dockerfile.gpu
@@ -102,12 +102,12 @@ RUN conda install -c pytorch magma-cuda101==2.5.1 \
  && conda install -y \
     scikit-learn==0.20.3 \
     pandas==0.24.2 \
-    Pillow==6.2.0 \
     h5py==2.9.0 \
     requests==2.22.0 \
  && pip install -U \
     awscli \
     scipy==1.2.2 \
+    Pillow==6.2.2 \
     sphinxcontrib-websupport==1.1.2 \
     "spyder<4.0" \
     argparse \

--- a/docker/1.4.0/py3/Dockerfile.cpu
+++ b/docker/1.4.0/py3/Dockerfile.cpu
@@ -78,7 +78,6 @@ RUN curl -o ~/miniconda.sh -O  https://repo.continuum.io/miniconda/Miniconda3-la
  && conda install -y \
     scikit-learn==0.21.2 \
     pandas==0.25.0 \
-    Pillow==6.2.0 \
     h5py==2.9.0 \
     requests==2.22.0 \
  && conda install -c dglteam -y dgl==0.4.1 \
@@ -93,6 +92,7 @@ RUN pip install --upgrade pip --trusted-host pypi.org --trusted-host files.pytho
     awscli \
     fastai==1.0.59 \
     scipy==1.2.2 \
+    Pillow==7.1.0 \
     smdebug==0.7.1 \
     sagemaker==1.50.17 \
     sagemaker-experiments==0.1.7 \

--- a/docker/1.4.0/py3/Dockerfile.gpu
+++ b/docker/1.4.0/py3/Dockerfile.gpu
@@ -98,7 +98,6 @@ RUN conda install -c pytorch magma-cuda101==2.5.1 \
     opencv==4.0.1 \
  && conda install -y scikit-learn==0.21.2 \
     pandas==0.25.0 \
-    Pillow==6.2.0 \
     h5py==2.9.0 \
     requests==2.22.0 \
  && conda clean -ya
@@ -124,6 +123,7 @@ RUN pip install \
     --no-cache-dir fastai==1.0.59 \
     awscli \
     scipy==1.2.2 \
+    Pillow==7.1.0 \
  && pip install --no-cache-dir -U https://pytorch-aws.s3.amazonaws.com/pytorch-1.4.0/py3/gpu/torch-1.4.0-cp36-cp36m-manylinux1_x86_64.whl \
  && pip uninstall -y torchvision \
  && pip install --no-cache-dir -U \


### PR DESCRIPTION
*Issue #, if available:*
Safety issue
```
-> pillow, installed 6.2.0, affected <6.2.2, id 37782
libImaging/FliDecode.c in Pillow before 6.2.2 has an FLI buffer overflow. See: CVE-2020-5313.
--
-> pillow, installed 6.2.0, affected <6.2.2, id 37781
libImaging/PcxDecode.c in Pillow before 6.2.2 has a PCX P mode buffer overflow. See:CVE-2020-5312.
--
-> pillow, installed 6.2.0, affected <6.2.2, id 37780
libImaging/SgiRleDecode.c in Pillow before 6.2.2 has an SGI buffer overflow. See: CVE-2020-5311.
--
-> pillow, installed 6.2.0, affected <6.2.2, id 37779
libImaging/TiffDecode.c in Pillow before 6.2.2 has a TIFF decoding integer overflow, related to realloc. See: CVE-2020-5310.
--
-> pillow, installed 6.2.0, affected >6.0,<6.2.2, id 37772
There is a DoS vulnerability in Pillow before 6.2.2 caused by FpxImagePlugin.py calling the range function on an unvalidated 32-bit integer if the number of bands is large. On Windows running 32-bit Python, this results in an OverflowError or MemoryError due to the 2 GB limit. However, on Linux running 64-bit Python this results in the process being terminated by the OOM killer. See: CVE-2019-19911.
```
*Description of changes:*
Upgrade Pillow to latest version for py2 and py3 correspondingly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
