### PR TITLE
Upgrade sagemaker-containers and test with more than 1 epoch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
 
     install_requires=[
         'retrying',
-        'sagemaker-containers>=2.8.2',
+        'sagemaker-containers>=2.8.6',
         'six>=1.12.0',
         'sagemaker-experiments==0.1.7;python_version>="3.6"'],
     extras_require={

--- a/test-toolkit/integration/sagemaker/test_mnist.py
+++ b/test-toolkit/integration/sagemaker/test_mnist.py
@@ -39,7 +39,7 @@ def _test_mnist_distributed(sagemaker_session, image_uri, instance_type, dist_ba
                           train_instance_type=instance_type,
                           sagemaker_session=sagemaker_session,
                           image_name=image_uri,
-                          hyperparameters={'backend': dist_backend, 'epochs': 1})
+                          hyperparameters={'backend': dist_backend, 'epochs': 2})
         training_input = pytorch.sagemaker_session.upload_data(path=training_dir,
                                                                key_prefix='pytorch/mnist')
         pytorch.fit({'training': training_input})

--- a/test/integration/sagemaker/test_mnist.py
+++ b/test/integration/sagemaker/test_mnist.py
@@ -39,7 +39,7 @@ def _test_mnist_distributed(sagemaker_session, ecr_image, instance_type, dist_ba
                           train_instance_type=instance_type,
                           sagemaker_session=sagemaker_session,
                           image_name=ecr_image,
-                          hyperparameters={'backend': dist_backend, 'epochs': 1})
+                          hyperparameters={'backend': dist_backend, 'epochs': 2})
         training_input = pytorch.sagemaker_session.upload_data(path=training_dir,
                                                                key_prefix='pytorch/mnist')
         pytorch.fit({'training': training_input})


### PR DESCRIPTION
*Description of changes:*
- Consume changes from https://github.com/aws/sagemaker-containers/pull/268
- Update test to train with more than 1 epoch

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
