### PR TITLE
infra: parallelize SageMaker integ test runs

### DIFF
--- a/buildspec-toolkit.yml
+++ b/buildspec-toolkit.yml
@@ -72,17 +72,18 @@ phases:
       - execute-command-if-has-matching-changes "$test_cmd" "test-toolkit/" "src/*.py" "setup.py" "setup.cfg" "buildspec-toolkit.yml" "docker/build_artifacts/*"
 
       # run CPU sagemaker integration tests
-      - test_cmd="pytest test-toolkit/integration/sagemaker --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --processor cpu --instance-type $CPU_INSTANCE_TYPE --tag $GENERIC_TAG"
+      - test_cmd="pytest -n 10 test-toolkit/integration/sagemaker --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --processor cpu --instance-type $CPU_INSTANCE_TYPE --tag $GENERIC_TAG"
       - execute-command-if-has-matching-changes "$test_cmd" "test-toolkit/" "src/*.py" "setup.py" "setup.cfg" "buildspec-toolkit.yml" "docker/build_artifacts/*"
-      - test_cmd="pytest test-toolkit/integration/sagemaker --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --processor cpu --instance-type $CPU_INSTANCE_TYPE --tag $DLC_CPU_TAG"
+      - test_cmd="pytest -n 10 test-toolkit/integration/sagemaker --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --processor cpu --instance-type $CPU_INSTANCE_TYPE --tag $DLC_CPU_TAG"
       - execute-command-if-has-matching-changes "$test_cmd" "test-toolkit/" "src/*.py" "setup.py" "setup.cfg" "buildspec-toolkit.yml" "docker/build_artifacts/*"
 
       # run GPU sagemaker integration tests
-      - test_cmd="pytest test-toolkit/integration/sagemaker --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --processor gpu --instance-type $GPU_INSTANCE_TYPE --tag $GENERIC_TAG"
+      - test_cmd="pytest -n 10 test-toolkit/integration/sagemaker --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --processor gpu --instance-type $GPU_INSTANCE_TYPE --tag $GENERIC_TAG"
       - execute-command-if-has-matching-changes "$test_cmd" "test-toolkit/" "src/*.py" "setup.py" "setup.cfg" "buildspec-toolkit.yml" "docker/build_artifacts/*"
-      - test_cmd="pytest test-toolkit/integration/sagemaker --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --processor gpu --instance-type $GPU_INSTANCE_TYPE --tag $DLC_GPU_TAG"
+      - test_cmd="pytest -n 10 test-toolkit/integration/sagemaker --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --processor gpu --instance-type $GPU_INSTANCE_TYPE --tag $DLC_GPU_TAG"
       - execute-command-if-has-matching-changes "$test_cmd" "test-toolkit/" "src/*.py" "setup.py" "setup.cfg" "buildspec-toolkit.yml" "docker/build_artifacts/*"
     finally:
+
       # shut down remote GPU instance
       - cleanup-gpu-instances
       - cleanup-key-pairs

--- a/buildspec-toolkit.yml
+++ b/buildspec-toolkit.yml
@@ -82,8 +82,8 @@ phases:
       - execute-command-if-has-matching-changes "$test_cmd" "test-toolkit/" "src/*.py" "setup.py" "setup.cfg" "buildspec-toolkit.yml" "docker/build_artifacts/*"
       - test_cmd="pytest -n 10 test-toolkit/integration/sagemaker --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --processor gpu --instance-type $GPU_INSTANCE_TYPE --tag $DLC_GPU_TAG"
       - execute-command-if-has-matching-changes "$test_cmd" "test-toolkit/" "src/*.py" "setup.py" "setup.cfg" "buildspec-toolkit.yml" "docker/build_artifacts/*"
-    finally:
 
+    finally:
       # shut down remote GPU instance
       - cleanup-gpu-instances
       - cleanup-key-pairs

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -90,15 +90,15 @@ phases:
       - execute-command-if-has-matching-changes "$test_cmd" "test/" "tests/" "docker/*" "buildspec.yml"
 
       # run cpu sagemaker tests
-      - test_cmd="pytest test/integration/sagemaker --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --py-version $CPU_PY3_VERSION --processor cpu --instance-type $CPU_INSTANCE_TYPE --tag $CPU_PY3_TAG"
+      - test_cmd="pytest -n 15 test/integration/sagemaker --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --py-version $CPU_PY3_VERSION --processor cpu --instance-type $CPU_INSTANCE_TYPE --tag $CPU_PY3_TAG"
       - execute-command-if-has-matching-changes "$test_cmd" "test/" "tests/" "docker/*" "buildspec.yml"
-      - test_cmd="pytest test/integration/sagemaker --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --py-version $CPU_PY2_VERSION --processor cpu --instance-type $CPU_INSTANCE_TYPE --tag $CPU_PY2_TAG"
+      - test_cmd="pytest -n 15 test/integration/sagemaker --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --py-version $CPU_PY2_VERSION --processor cpu --instance-type $CPU_INSTANCE_TYPE --tag $CPU_PY2_TAG"
       - execute-command-if-has-matching-changes "$test_cmd" "test/" "tests/" "docker/*" "buildspec.yml"
 
       # run gpu sagemaker tests
-      - test_cmd="pytest test/integration/sagemaker --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --py-version $GPU_PY3_VERSION --processor gpu --instance-type $GPU_INSTANCE_TYPE --tag $GPU_PY3_TAG"
+      - test_cmd="pytest -n 15 test/integration/sagemaker --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --py-version $GPU_PY3_VERSION --processor gpu --instance-type $GPU_INSTANCE_TYPE --tag $GPU_PY3_TAG"
       - execute-command-if-has-matching-changes "$test_cmd" "test/" "tests/" "docker/*" "buildspec.yml"
-      - test_cmd="pytest test/integration/sagemaker --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --py-version $GPU_PY2_VERSION --processor gpu --instance-type $GPU_INSTANCE_TYPE --tag $GPU_PY2_TAG"
+      - test_cmd="pytest -n 15 test/integration/sagemaker --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --py-version $GPU_PY2_VERSION --processor gpu --instance-type $GPU_INSTANCE_TYPE --tag $GPU_PY2_TAG"
       - execute-command-if-has-matching-changes "$test_cmd" "test/" "tests/" "docker/*" "buildspec.yml"
 
     finally:

--- a/test-toolkit/integration/sagemaker/test_distributed_operations.py
+++ b/test-toolkit/integration/sagemaker/test_distributed_operations.py
@@ -16,6 +16,7 @@ import os
 
 import boto3
 import pytest
+from sagemaker import utils
 from sagemaker.pytorch import PyTorch
 from six.moves.urllib.parse import urlparse
 
@@ -59,7 +60,9 @@ def test_mnist_gpu(sagemaker_session, image_uri, dist_gpu_backend):
 
         training_input = sagemaker_session.upload_data(path=os.path.join(data_dir, 'training'),
                                                        key_prefix='pytorch/mnist')
-        pytorch.fit({'training': training_input})
+
+        job_name = utils.unique_name_from_base('test-pytorch-dist-ops')
+        pytorch.fit({'training': training_input}, job_name=job_name)
 
 
 def _test_dist_operations(sagemaker_session, image_uri, instance_type, dist_backend, train_instance_count=3):
@@ -71,10 +74,13 @@ def _test_dist_operations(sagemaker_session, image_uri, instance_type, dist_back
                           sagemaker_session=sagemaker_session,
                           image_name=image_uri,
                           hyperparameters={'backend': dist_backend})
+
         pytorch.sagemaker_session.default_bucket()
         fake_input = pytorch.sagemaker_session.upload_data(path=dist_operations_path,
                                                            key_prefix='pytorch/distributed_operations')
-        pytorch.fit({'required_argument': fake_input})
+
+        job_name = utils.unique_name_from_base('test-pytorch-dist-ops')
+        pytorch.fit({'required_argument': fake_input}, job_name=job_name)
 
 
 def _assert_s3_file_exists(region, s3_url):

--- a/test-toolkit/integration/sagemaker/test_mnist.py
+++ b/test-toolkit/integration/sagemaker/test_mnist.py
@@ -13,6 +13,7 @@
 from __future__ import absolute_import
 
 import pytest
+from sagemaker import utils
 from sagemaker.pytorch import PyTorch
 
 from integration import training_dir, mnist_script, DEFAULT_TIMEOUT
@@ -42,4 +43,7 @@ def _test_mnist_distributed(sagemaker_session, image_uri, instance_type, dist_ba
                           hyperparameters={'backend': dist_backend, 'epochs': 2})
         training_input = pytorch.sagemaker_session.upload_data(path=training_dir,
                                                                key_prefix='pytorch/mnist')
-        pytorch.fit({'training': training_input})
+
+        job_name = utils.unique_name_from_base('test-pytorch-mnist')
+
+        pytorch.fit({'training': training_input}, job_name=job_name)

--- a/test/integration/sagemaker/test_mnist.py
+++ b/test/integration/sagemaker/test_mnist.py
@@ -13,6 +13,7 @@
 from __future__ import absolute_import
 
 import pytest
+from sagemaker import utils
 from sagemaker.pytorch import PyTorch
 
 from test.integration import training_dir, mnist_script, DEFAULT_TIMEOUT
@@ -40,6 +41,9 @@ def _test_mnist_distributed(sagemaker_session, ecr_image, instance_type, dist_ba
                           sagemaker_session=sagemaker_session,
                           image_name=ecr_image,
                           hyperparameters={'backend': dist_backend, 'epochs': 2})
+
         training_input = pytorch.sagemaker_session.upload_data(path=training_dir,
                                                                key_prefix='pytorch/mnist')
-        pytorch.fit({'training': training_input})
+        job_name = utils.unique_name_from_base('test-pytorch-mnist')
+
+        pytorch.fit({'training': training_input}, job_name=job_name)

--- a/test/integration/sagemaker/test_training_smdebug.py
+++ b/test/integration/sagemaker/test_training_smdebug.py
@@ -13,6 +13,7 @@
 from __future__ import absolute_import
 
 import pytest
+from sagemaker import utils
 from sagemaker.pytorch import PyTorch
 
 from test.integration import training_dir, smdebug_mnist_script, DEFAULT_TIMEOUT
@@ -32,6 +33,9 @@ def test_training_smdebug(sagemaker_session, ecr_image, instance_type):
                           sagemaker_session=sagemaker_session,
                           image_name=ecr_image,
                           hyperparameters=hyperparameters)
+
         training_input = pytorch.sagemaker_session.upload_data(path=training_dir,
                                                                key_prefix='pytorch/mnist')
-        pytorch.fit({'training': training_input})
+        job_name = utils.unique_name_from_base('test-pytorch-smdebug')
+
+        pytorch.fit({'training': training_input}, job_name=job_name)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This is to speed up the PR builds. I set `n` to the number of tests, as determined by `pytest --collect-only`.

It seems to have helped with the overall times:
* the toolkit one normally takes 2-2.5 hours; this time it took just under an hour
* the other one normally takes 4 hours; this time it took a little over 2 hours

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
