### PR TITLE
fix: Bump version of sagemaker-training for typing fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
 
     install_requires=[
         'retrying',
-        'sagemaker-training>=3.5.0',
+        'sagemaker-training>=3.5.1',
         'six>=1.12.0',
         'sagemaker-experiments==0.1.7;python_version>="3.6"'],
     extras_require={


### PR DESCRIPTION
*Description of changes:*
This consumes the change from this PR: https://github.com/aws/sagemaker-training-toolkit/pull/61


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
