### PR TITLE
change: install ipywidgets in 1.5.0 Python 3 Dockerfiles

### DIFF
--- a/docker/1.5.0/py3/Dockerfile.cpu
+++ b/docker/1.5.0/py3/Dockerfile.cpu
@@ -91,6 +91,7 @@ RUN pip install --upgrade pip --trusted-host pypi.org --trusted-host files.pytho
  && pip install --no-cache-dir -U \
     awscli \
     fastai==1.0.59 \
+    ipywidgets==7.5.1 \
     scipy==1.2.2 \
     smdebug==0.7.2 \
     sagemaker==1.50.17 \

--- a/docker/1.5.0/py3/Dockerfile.gpu
+++ b/docker/1.5.0/py3/Dockerfile.gpu
@@ -86,6 +86,7 @@ RUN ompi_info --parsable --all | grep mpi_built_with_cuda_support:value \
     python=$PYTHON_VERSION \
     numpy==1.16.4 \
     ipython==7.10.1 \
+    ipywidgets==7.5.1 \
     mkl==2019.4 \
     mkl-include==2019.4 \
     cython==0.29.12 \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This is so that `torchvision.datasets` can be used to download datasets when using the PyTorch kernel in SageMaker Studio. I tested it by building the CPU image, running it locally, and running `jupyter notebook` from the container.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
